### PR TITLE
allow constant force to be directly applied to a rigid body, RNA path…

### DIFF
--- a/intern/rigidbody/RBI_api.h
+++ b/intern/rigidbody/RBI_api.h
@@ -230,7 +230,7 @@ void RB_body_get_orientation(rbRigidBody *body, float v_out[4]);
 /* ............ */
 
 void RB_body_apply_central_force(rbRigidBody *body, const float v_in[3]);
-
+void RB_body_apply_central_impulse(rbRigidBody *body, const float v_in[3]);
 void RB_body_apply_impulse(rbRigidBody* object, const float impulse[3], const float pos[3]);
 void RB_body_apply_force(rbRigidBody* object, const float force[3], const float pos[3]);
 

--- a/intern/rigidbody/rb_bullet_api.cpp
+++ b/intern/rigidbody/rb_bullet_api.cpp
@@ -1522,6 +1522,11 @@ void RB_body_apply_impulse(rbRigidBody* object, const float impulse[3], const fl
 	body->applyImpulse(btVector3(impulse[0], impulse[1], impulse[2]), btVector3(pos[0], pos[1], pos[2]));
 }
 
+void RB_body_apply_central_impulse(rbRigidBody* object, const float impulse[3]) {
+	btRigidBody *body = object->body;
+	body->applyImpulse(btVector3(impulse[0], impulse[1], impulse[2]), btVector3(0.0, 0.0, 0.0));
+}
+
 void RB_body_apply_force(rbRigidBody* object, const float force[3], const float pos[3])
 {
 	btRigidBody *body = object->body;

--- a/source/blender/blenkernel/intern/rigidbody.c
+++ b/source/blender/blenkernel/intern/rigidbody.c
@@ -1823,6 +1823,11 @@ static void rigidbody_update_sim_ob(Scene *scene, RigidBodyWorld *rbw, Object *o
 	/* NOTE: no other settings need to be explicitly updated here,
 	 * since RNA setters take care of the rest :)
 	 */
+
+	// per-object constant linear force //
+	if (rbo->type == RBO_TYPE_ACTIVE){
+		RB_body_apply_central_force(rbo->physics_object, rbo->apply_force);
+	}
 }
 
 /* Updates and validates world, bodies and shapes.

--- a/source/blender/makesdna/DNA_rigidbody_types.h
+++ b/source/blender/makesdna/DNA_rigidbody_types.h
@@ -141,7 +141,8 @@ typedef struct RigidBodyOb {
 	float pos[3];			/* rigid body position */
 	float lin_vel[3];		/* rigid body linear velocity, important for dynamic fracture*/
 	float ang_vel[3];		/* rigid body angular velocity, important for dynamic fracture*/
-	//float pad1;
+	float apply_force[3];	/* rigid body aux linear velocity*/
+	float apply_ang_force[3];/* rigid body aux angular velocity*/
 } RigidBodyOb;
 
 

--- a/source/blender/makesrna/intern/rna_rigidbody.c
+++ b/source/blender/makesrna/intern/rna_rigidbody.c
@@ -1313,6 +1313,12 @@ static void rna_def_rigidbody_object(BlenderRNA *brna)
 	prop = RNA_def_property(srna, "rotation", PROP_FLOAT, PROP_QUATERNION);
 	RNA_def_property_float_sdna(prop, NULL, "orn");
 	RNA_def_property_ui_text(prop, "Rotation", "Quaternion rotation of the rigidbody object");
+	//directly apply force
+	prop = RNA_def_property(srna, "apply_force", PROP_FLOAT, PROP_TRANSLATION);
+	RNA_def_property_float_sdna(prop, NULL, "apply_force");
+	RNA_def_property_ui_text(prop, "Linear Force", "linear force applied to the rigidbody object");
+	RNA_def_property_update(prop, NC_OBJECT | ND_POINTCACHE, "rna_RigidBodyOb_reset");
+
 }
 
 static void rna_def_rigidbody_constraint(BlenderRNA *brna)


### PR DESCRIPTION
current blender makes it hard to apply simple force for each object, using force emitter objects with falloff is overkill for this basic feature.  this is used from python by setting `object.rigid_body.apply_force = [x,y,z]`